### PR TITLE
Add option to always require approval for comments

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -111,7 +111,7 @@ func (s *Server) postComment(ctx context.Context, w http.ResponseWriter, req *ht
 	content, _ := json.Marshal(comment)
 	branch := "master"
 
-	if comment.IsSuspicious() {
+	if settings.RequireApproval || comment.IsSuspicious() {
 		branch = "comment-" + comment.ID
 		master, _, err := s.client.Repositories.GetBranch(ctx, parts[0], parts[1], "master")
 		sha := master.Commit.GetSHA()

--- a/api/settings.go
+++ b/api/settings.go
@@ -11,11 +11,12 @@ import (
 const settingsRefreshTime = 10 * time.Minute
 
 type settings struct {
-	BannedIPs      []string `json:"banned_ips"`
-	BannedKeywords []string `json:"banned_keywords"`
-	BannedEmails   []string `json:"banned_emails"`
-	TimeLimit      int      `json:"timelimit"`
-	lastLoad       time.Time
+	BannedIPs       []string `json:"banned_ips"`
+	BannedKeywords  []string `json:"banned_keywords"`
+	BannedEmails    []string `json:"banned_emails"`
+	RequireApproval bool     `json:"require_approval"`
+	TimeLimit       int      `json:"timelimit"`
+	lastLoad        time.Time
 }
 
 func (s *settings) fresh() bool {


### PR DESCRIPTION
This allows a setting to always require approval for all new comments.