### PR TITLE
Truncate commit message if first paragraph is over 256 chars

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -108,6 +108,10 @@ func (s *Server) postComment(ctx context.Context, w http.ResponseWriter, req *ht
 		fmt.Sprintf("%v-%v.json", (time.Now().UnixNano()/1000000), name),
 	)
 
+	message := firstParagraph
+	if len(message) > 255 {
+		message = message[:255]
+	}
 	content, _ := json.Marshal(comment)
 	branch := "master"
 
@@ -129,7 +133,6 @@ func (s *Server) postComment(ctx context.Context, w http.ResponseWriter, req *ht
 			jsonError(w, fmt.Sprintf("Failed to create comment branch: %v", err), 500)
 			return
 		}
-		message := firstParagraph
 		_, _, err = s.client.Repositories.CreateFile(ctx, parts[0], parts[1], pathname, &github.RepositoryContentFileOptions{
 			Message: &message,
 			Content: content,
@@ -152,7 +155,6 @@ func (s *Server) postComment(ctx context.Context, w http.ResponseWriter, req *ht
 			return
 		}
 	} else {
-		message := firstParagraph
 		_, _, err = s.client.Repositories.CreateFile(ctx, parts[0], parts[1], pathname, &github.RepositoryContentFileOptions{
 			Message: &message,
 			Content: content,


### PR DESCRIPTION
**Requires #16**
*Fixes #14*

**- Summary**

Because the first paragraph of the comment body becomes the commit message a comment would fail if the first paragraph had more than 256 characters.
The message is now being truncated on that limit. It does not respect utf-8 runes currently, so it might break emojis on the truncation border.

**- Test plan**

Simple change. Decided against regression test since coverage is really bad anyways.

**- Description for the changelog**

Allow comments with a first paragraph longer than 256 chars

**- A picture of a cute animal (not mandatory but encouraged)**

![baby penguin](https://i.pinimg.com/originals/c8/77/4f/c8774f2ceb3f6e4c0163b05b7c255f06.jpg)
